### PR TITLE
API Refactoring

### DIFF
--- a/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/FlutterResult+CustomErrors.kt
+++ b/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/FlutterResult+CustomErrors.kt
@@ -1,0 +1,23 @@
+package com.qonversion.flutter.sdk.qonversion_flutter_sdk
+
+import io.flutter.plugin.common.MethodChannel
+
+fun MethodChannel.Result.noArgsError() {
+    return this.error("0", "Could not find call arguments", "Make sure you pass Map as call arguments")
+}
+
+fun MethodChannel.Result.noApiKeyError() {
+    return this.error("1", "Could not find API key", "Make sure you pass Map as call arguments")
+}
+
+fun MethodChannel.Result.noUserIdError() {
+    return this.error("2", "Could not find userID", "Make sure you pass Map as call arguments")
+}
+
+fun MethodChannel.Result.noAutoTrackPurchasesError() {
+    return this.error("3", "Could not find autoTrackPurchases boolean value", "Make sure you pass Map as call arguments")
+}
+
+fun MethodChannel.Result.qonversionError(message: String, cause: String) {
+    return this.error("9", message, cause)
+}

--- a/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionFlutterSdkPlugin.kt
@@ -27,23 +27,62 @@ class QonversionFlutterSdkPlugin internal constructor(registrar: Registrar): Met
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-        val args = call.arguments as? Map<String, Any> ?: return result.error("1",
-                "Please provide arguments",
-                "There was no arguments in method call")
+        val args = call.arguments<Map<String, Any>>()
 
-        val key = args["key"] as? String
+        if (args == null || args.isEmpty()) {
+            result.noArgsError()
+            return
+        }
+
+        val apiKey = call.argument<String>("key")
+        if (apiKey == null) {
+            result.noApiKeyError()
+            return
+        }
+
         val internalUserId = args["userID"] as? String ?: ""
         val autoTrackPurchases = args["autoTrackPurchases"] as? Boolean ?: true
 
         when (call.method) {
-            "launchWithKeyCompletion" -> launchWith(key, internalUserId, autoTrackPurchases, result)
-            "launchWithKeyUserId" -> launchWith(key, internalUserId, autoTrackPurchases, result)
-            "launchWithKeyAutoTrackPurchasesCompletion" -> launchWith(key, internalUserId, autoTrackPurchases, result)
+            "launch" -> launch(apiKey, args, result)
+
+            // TODO remove when old methods get removed on Dart side
+            "launchWithKeyCompletion",
+            "launchWithKeyUserId",
+            "launchWithKeyAutoTrackPurchasesCompletion" -> launchWith(apiKey, internalUserId, autoTrackPurchases, result)
             "addAttributionData" -> result.notImplemented() // since there is no such method in Android SDK
             else -> result.notImplemented()
         }
     }
 
+    private fun launch(apiKey: String, args: Map<String, Any>, result: Result) {
+        val userId = args["userID"] as? String ?: ""
+
+        val billingBuilder = QonversionBillingBuilder()
+                .enablePendingPurchases()
+                .setListener { _, _ ->  }
+
+        val callback = object: QonversionCallback {
+            override fun onSuccess(uid: String) {
+                result.success(uid)
+            }
+
+            override fun onError(t: Throwable) {
+                result.qonversionError(t.localizedMessage, t.cause.toString())
+            }
+        }
+
+        Qonversion.initialize(
+                application,
+                apiKey,
+                userId,
+                billingBuilder,
+                true,
+                callback
+        )
+    }
+
+    // TODO remove when old methods get removed on Dart side
     private fun launchWith(key: String?,
                            internalUserId: String = "",
                            autoTrackPurchases: Boolean = true,
@@ -62,7 +101,7 @@ class QonversionFlutterSdkPlugin internal constructor(registrar: Registrar): Met
             }
 
             override fun onError(t: Throwable) {
-                result.error("1", t.localizedMessage, t.cause.toString())
+                result.qonversionError(t.localizedMessage, t.cause.toString())
             }
         }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'dart:async';
 
-import 'package:flutter/services.dart';
 import 'package:qonversion_flutter/qonversion.dart';
 
 void main() => runApp(MyApp());
@@ -23,14 +22,11 @@ class _MyAppState extends State<MyApp> {
   Future<void> initPlatformState() async {
     String uid;
     try {
-      await Qonversion.launchWith(
+      uid = await Qonversion.launch(
         iosApiKey: '',
         androidApiKey: '',
-        onComplete: (receivedUid) {
-          uid = receivedUid;
-          print(uid);
-        },
       );
+      print(uid);
     } catch (e) {
       print('Failed to obtain uid from Qonversion.');
       print(e);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,6 +31,7 @@ class _MyAppState extends State<MyApp> {
       print('Failed to obtain uid from Qonversion.');
       print(e);
     }
+
     if (!mounted) return;
 
     setState(() => _uid = uid);

--- a/ios/Classes/FlutterError+Custom.swift
+++ b/ios/Classes/FlutterError+Custom.swift
@@ -1,0 +1,34 @@
+//
+//  FlutterError+Custom.swift
+//  Pods-Runner
+//
+//  Created by Ilya Virnik on 6/21/20.
+//
+
+import Flutter
+
+extension FlutterError {
+    static let noArgs = FlutterError(code: "0",
+                                     message: "Could not find call arguments",
+                                     details: "Make sure you pass Map as call arguments")
+    
+    static let noApiKey = FlutterError(code: "1",
+                                    message: "Could not find API key",
+                                    details: "Please make sure you pass a valid value")
+    
+    static let noUserId = FlutterError(code: "2",
+                                       message: "Could not find userID",
+                                       details: "Please make sure you pass a valid value")
+    
+    static let noAutoTrackPurchases = FlutterError(code: "3",
+                                                   message: "Could not find autoTrackPurchases boolean value",
+                                                   details: "Please make sure you pass a valid value")
+    
+    static let noData = FlutterError(code: "4",
+                                     message: "Could not find data",
+                                     details: "Please make sure you pass a valid value")
+    
+    static let noProvider = FlutterError(code: "5",
+                                        message: "Could not find provider",
+                                        details: "Please make sure you pass a valid value")
+}

--- a/ios/Classes/SwiftQonversionFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftQonversionFlutterSdkPlugin.swift
@@ -11,30 +11,58 @@ public class SwiftQonversionFlutterSdkPlugin: NSObject, FlutterPlugin {
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let args = call.arguments as? [String: Any] else {
-            return result("Could not find call arguments. Make sure you pass Map as call arguments")
+            result(FlutterError.noArgs)
+            return
         }
+        
+        guard let apiKey = args["key"] as? String, !apiKey.isEmpty else {
+            result(FlutterError.noApiKey)
+            return
+        }
+        
         switch call.method {
+        case "launch":
+            launch(with: apiKey, args, result)
+            
         case "launchWithKeyCompletion":
-            guard let key = args["key"] as? String else {
-                return result("Could not find API key, please make sure you pass a valid value")
-            }
-            return launch(with: key, result)
+            launch(with: apiKey, result)
+            
         case "launchWithKeyUserId":
-            guard let key = args["key"] as? String,
-                let userID = args["userID"] as? String else {
-                return result("Could not find either API key or userID, please make sure you pass a valid value")
+            guard let userID = args["userID"] as? String else {
+                result(FlutterError.noUserId)
+                return
             }
-            return launch(with: key, userID: userID, result)
+            
+            launch(with: apiKey, userID: userID, result)
+            
         case "launchWithKeyAutoTrackPurchasesCompletion":
-            guard let key = args["key"] as? String,
-                let autoTrackPurchases = args["autoTrackPurchases"] as? Bool else {
-                    return result("Could not find either key or autoTrackPurchases boolean value, make sure you pass it as a {\"autoTrackPurchases\": autoTrackPurchases} key-value pair to call arguments")
+            guard let autoTrackPurchases = args["autoTrackPurchases"] as? Bool else {
+                result(FlutterError.noAutoTrackPurchases)
+                return
             }
-            return launch(with: key, autoTrackPurchases: autoTrackPurchases, result)
+            
+            launch(with: apiKey, autoTrackPurchases: autoTrackPurchases, result)
+            
         case "addAttributionData":
-            return addAttributionData(args: args, result)
+            addAttributionData(args: args, result)
+            
         default:
             result(FlutterMethodNotImplemented)
+        }
+    }
+    
+    private func launch(with apiKey: String,
+                        _ args: [String: Any],
+                        _ result: @escaping FlutterResult) {
+        let userId = args["userID"] as? String
+        
+        if let userId = userId {
+            Qonversion.launch(withKey: apiKey, userID: userId)
+            result(userId)
+        } else {
+            Qonversion.launch(withKey: apiKey) { uid in
+                result(uid)
+            }
         }
     }
     
@@ -57,9 +85,16 @@ public class SwiftQonversionFlutterSdkPlugin: NSObject, FlutterPlugin {
     }
     
     private func addAttributionData(args: [String: Any], _ result: @escaping FlutterResult) {
-        guard let data = args["data"] as? [AnyHashable: Any], let provider = args["provider"] as? String else {
+        guard let data = args["data"] as? [AnyHashable: Any] else {
+            result(FlutterError.noData)
             return
         }
+        
+        guard let provider = args["provider"] as? String else {
+            result(FlutterError.noProvider)
+            return
+        }
+        
         // Using appsFlyer by default since there are only 2 cases in an enum yet.
         var castedProvider = QAttributionProvider.appsFlyer
         

--- a/lib/qonversion.dart
+++ b/lib/qonversion.dart
@@ -16,10 +16,39 @@ class Qonversion {
   /// [androidApiKey] and [iosApiKey] respectively,
   /// you can get one in your account on qonversion.io.
   ///
+  /// Returns `userId` for Ads integrations.
+  ///
+  /// **Warning**:
+  /// Qonversion will track any purchase events (trials, subscriptions, basic purchases) automatically.
+  static Future<String> launch({
+    @required String androidApiKey,
+    @required String iosApiKey,
+    String userId,
+  }) async {
+    final apiKey = _obtainPlatformApiKey(
+      androidApiKey: androidApiKey,
+      iosApiKey: iosApiKey,
+    );
+
+    final args = {
+      Constants.kApiKey: apiKey,
+      Constants.kUserId: userId,
+    };
+
+    final uid = await _channel.invokeMethod(Constants.mLaunch, args);
+
+    return uid;
+  }
+
+  /// Launches Qonversion SDK with the given API keys for each platform:
+  /// [androidApiKey] and [iosApiKey] respectively,
+  /// you can get one in your account on qonversion.io.
+  ///
   /// [onComplete] will return `uid` for Ads integrations.
   ///
   /// **Warning**:
   /// Qonversion will track any purchase events (trials, subscriptions, basic purchases) automatically.
+  @Deprecated("Use `launch` method instead")
   static Future<void> launchWith({
     String androidApiKey,
     String iosApiKey,
@@ -42,6 +71,7 @@ class Qonversion {
   /// you can get one in your account on qonversion.io.
   ///
   /// Sets client side [userid] (instead of Qonversion user-id) that will be used for matching data in the third party data.
+  @Deprecated("Use `launch` method instead")
   static Future<void> launchWithClientSideUserId(
     String userID, {
     String androidApiKey,
@@ -71,6 +101,7 @@ class Qonversion {
   /// Will track any purchase events (trials, subscriptions, basic purchases) automatically.
   /// But if `autoTrackPurchases` disabled you need to call `trackPurchase:transaction:` method (under development yet).
   /// Otherwise, purchases tracking won't work.
+  @Deprecated("Use `launch` method instead")
   static Future<void> launchWithAutoTrackPurchases(
     bool autoTrackPurchases, {
     String androidApiKey,

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -7,6 +7,7 @@ class Constants {
   static const kProvider = 'provider';
 
   // MethodChannel methods names
+  static const mLaunch = 'launch';
   static const mLaunchWithKeyCompletion = 'launchWithKeyCompletion';
   static const mLaunchWithKeyUserId = 'launchWithKeyUserId';
   static const mLaunchWithKeyAutoTrackPurchasesCompletion =


### PR DESCRIPTION
**Changes:**
* Use just 1 `launch` method instead of inconvenient several different methods
* Deprecate all old `launch...` methods
* Use custom Flutter Errors to return from platform code in different error cases