### PR TITLE
Bugfix - Android Tracking

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.qonversion.android.sdk:sdk:0.3.0"
+    implementation "com.qonversion.android.sdk:sdk:1.0.5"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Jul 05 12:59:07 MSK 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionFlutterSdkPlugin.kt
@@ -2,14 +2,16 @@ package com.qonversion.flutter.sdk.qonversion_flutter_sdk
 
 import android.app.Activity
 import android.app.Application
-import androidx.annotation.NonNull;
+import androidx.annotation.NonNull
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.SkuDetails
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
-import com.qonversion.android.sdk.Qonversion;
+import com.qonversion.android.sdk.Qonversion
 import com.qonversion.android.sdk.QonversionBillingBuilder
 import com.qonversion.android.sdk.QonversionCallback
 
@@ -27,40 +29,32 @@ class QonversionFlutterSdkPlugin internal constructor(registrar: Registrar): Met
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-        val args = call.arguments<Map<String, Any>>()
+        val args = call.arguments() as? Map<String, Any> ?: return result.noArgsError()
 
-        if (args == null || args.isEmpty()) {
-            result.noArgsError()
-            return
-        }
-
-        val apiKey = call.argument<String>("key")
-        if (apiKey == null) {
-            result.noApiKeyError()
-            return
+        if (args.isEmpty()) {
+            return result.noArgsError()
         }
 
         val internalUserId = args["userID"] as? String ?: ""
         val autoTrackPurchases = args["autoTrackPurchases"] as? Boolean ?: true
 
         when (call.method) {
-            "launch" -> launch(apiKey, args, result)
+            "launch" -> launch(args, result)
+            "trackPurchase" -> trackPurchase(args, result)
 
             // TODO remove when old methods get removed on Dart side
             "launchWithKeyCompletion",
             "launchWithKeyUserId",
-            "launchWithKeyAutoTrackPurchasesCompletion" -> launchWith(apiKey, internalUserId, autoTrackPurchases, result)
+            "launchWithKeyAutoTrackPurchasesCompletion" -> launchWith(args["key"] as String, internalUserId, autoTrackPurchases, result)
             "addAttributionData" -> result.notImplemented() // since there is no such method in Android SDK
             else -> result.notImplemented()
         }
     }
 
-    private fun launch(apiKey: String, args: Map<String, Any>, result: Result) {
-        val userId = args["userID"] as? String ?: ""
+    private fun launch(args: Map<String, Any>, result: Result) {
+        val apiKey = args["key"] as? String ?: return result.noApiKeyError()
 
-        val billingBuilder = QonversionBillingBuilder()
-                .enablePendingPurchases()
-                .setListener { _, _ ->  }
+        val userId = args["userID"] as? String ?: ""
 
         val callback = object: QonversionCallback {
             override fun onSuccess(uid: String) {
@@ -76,8 +70,6 @@ class QonversionFlutterSdkPlugin internal constructor(registrar: Registrar): Met
                 application,
                 apiKey,
                 userId,
-                billingBuilder,
-                true,
                 callback
         )
     }
@@ -113,5 +105,38 @@ class QonversionFlutterSdkPlugin internal constructor(registrar: Registrar): Met
                 autoTrackPurchases,
                 callback
         )
+    }
+
+    private fun trackPurchase(args: Map<String, Any>, result: Result) {
+        @Suppress("UNCHECKED_CAST")
+        val detailsMap = args["details"] as Map<String, Any>
+        @Suppress("UNCHECKED_CAST")
+        val purchaseMap = args["purchase"] as Map<String, Any>
+
+        val details = createSkuDetails(detailsMap)
+        val purchase = createPurchase(purchaseMap)
+
+        val callback = object: QonversionCallback {
+            override fun onSuccess(uid: String) {
+                result.success(uid)
+            }
+
+            override fun onError(t: Throwable) {
+                result.qonversionError(t.localizedMessage, t.cause.toString())
+            }
+        }
+
+        Qonversion.instance!!.purchase(details, purchase, callback)
+    }
+
+    private fun createSkuDetails(map: Map<String, Any>): SkuDetails {
+        val json = map.toString()
+        return SkuDetails(json)
+    }
+
+    private fun createPurchase(map: Map<String, Any>): Purchase {
+        val json = map.toString()
+        val signature = map["signature"] as String
+        return Purchase(json, signature)
     }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Sun Jul 05 12:39:57 MSK 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/lib/qonversion.dart
+++ b/lib/qonversion.dart
@@ -40,6 +40,18 @@ class Qonversion {
     return uid;
   }
 
+  Future<String> trackPurchase(
+      Map<String, dynamic> details, Map<String, dynamic> purchase) async {
+    final args = {
+      Constants.kDetails: details,
+      Constants.kPurchase: purchase,
+    };
+
+    final uid = await _channel.invokeMethod(Constants.mTrackPurchase, args);
+
+    return uid;
+  }
+
   /// Launches Qonversion SDK with the given API keys for each platform:
   /// [androidApiKey] and [iosApiKey] respectively,
   /// you can get one in your account on qonversion.io.

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -5,6 +5,8 @@ class Constants {
   static const kAutoTrackPurchases = 'autoTrackPurchases';
   static const kData = 'data';
   static const kProvider = 'provider';
+  static const kDetails = 'details';
+  static const kPurchase = 'purchase';
 
   // MethodChannel methods names
   static const mLaunch = 'launch';
@@ -13,4 +15,5 @@ class Constants {
   static const mLaunchWithKeyAutoTrackPurchasesCompletion =
       'launchWithKeyAutoTrackPurchasesCompletion';
   static const mAddAttributionData = 'addAttributionData';
+  static const mTrackPurchase = 'trackPurchase';
 }


### PR DESCRIPTION
* Added `trackPurchase` method to use on Android side to track purchases manually since there is no access to BillingBuilder created by Flutter using some other packages
* Updated Qonversion SDK version