### PR TITLE
Add attribution data support

### DIFF
--- a/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/FlutterResult+CustomErrors.kt
+++ b/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/FlutterResult+CustomErrors.kt
@@ -18,6 +18,14 @@ fun MethodChannel.Result.noAutoTrackPurchasesError() {
     return this.error("3", "Could not find autoTrackPurchases boolean value", "Make sure you pass Map as call arguments")
 }
 
+fun MethodChannel.Result.noDataError() {
+    return this.error("4", "Could not find data", "Please make sure you pass a valid value")
+}
+
+fun MethodChannel.Result.noProviderError() {
+    return this.error("5", "Could not find provider", "Please make sure you pass a valid value")
+}
+
 fun MethodChannel.Result.qonversionError(message: String, cause: String) {
     return this.error("9", message, cause)
 }

--- a/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionFlutterSdkPlugin.kt
@@ -13,7 +13,6 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
 import com.qonversion.android.sdk.Qonversion
-import com.qonversion.android.sdk.QonversionBillingBuilder
 import com.qonversion.android.sdk.QonversionCallback
 
 /** QonversionFlutterSdkPlugin */

--- a/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionFlutterSdkPlugin.kt
@@ -35,17 +35,9 @@ class QonversionFlutterSdkPlugin internal constructor(registrar: Registrar): Met
             return result.noArgsError()
         }
 
-        val internalUserId = args["userID"] as? String ?: ""
-        val autoTrackPurchases = args["autoTrackPurchases"] as? Boolean ?: true
-
         when (call.method) {
             "launch" -> launch(args, result)
             "trackPurchase" -> trackPurchase(args, result)
-
-            // TODO remove when old methods get removed on Dart side
-            "launchWithKeyCompletion",
-            "launchWithKeyUserId",
-            "launchWithKeyAutoTrackPurchasesCompletion" -> launchWith(args["key"] as String, internalUserId, autoTrackPurchases, result)
             "addAttributionData" -> result.notImplemented() // since there is no such method in Android SDK
             else -> result.notImplemented()
         }
@@ -70,39 +62,6 @@ class QonversionFlutterSdkPlugin internal constructor(registrar: Registrar): Met
                 application,
                 apiKey,
                 userId,
-                callback
-        )
-    }
-
-    // TODO remove when old methods get removed on Dart side
-    private fun launchWith(key: String?,
-                           internalUserId: String = "",
-                           autoTrackPurchases: Boolean = true,
-                           result: Result) {
-        if (key == null) {
-          return result.error("1", "Could not find API key", "Please provide valid API key")
-        }
-
-        val billingBuilder = QonversionBillingBuilder()
-                .enablePendingPurchases()
-                .setListener { _, _ ->  }
-
-        val callback = object: QonversionCallback {
-            override fun onSuccess(uid: String) {
-                result.success(uid)
-            }
-
-            override fun onError(t: Throwable) {
-                result.qonversionError(t.localizedMessage, t.cause.toString())
-            }
-        }
-
-        Qonversion.initialize(
-                application,
-                key,
-                internalUserId,
-                billingBuilder,
-                autoTrackPurchases,
                 callback
         )
     }

--- a/ios/Classes/SwiftQonversionFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftQonversionFlutterSdkPlugin.swift
@@ -24,25 +24,6 @@ public class SwiftQonversionFlutterSdkPlugin: NSObject, FlutterPlugin {
         case "launch":
             launch(with: apiKey, args, result)
             
-        case "launchWithKeyCompletion":
-            launch(with: apiKey, result)
-            
-        case "launchWithKeyUserId":
-            guard let userID = args["userID"] as? String else {
-                result(FlutterError.noUserId)
-                return
-            }
-            
-            launch(with: apiKey, userID: userID, result)
-            
-        case "launchWithKeyAutoTrackPurchasesCompletion":
-            guard let autoTrackPurchases = args["autoTrackPurchases"] as? Bool else {
-                result(FlutterError.noAutoTrackPurchases)
-                return
-            }
-            
-            launch(with: apiKey, autoTrackPurchases: autoTrackPurchases, result)
-            
         case "addAttributionData":
             addAttributionData(args: args, result)
             
@@ -66,24 +47,6 @@ public class SwiftQonversionFlutterSdkPlugin: NSObject, FlutterPlugin {
         }
     }
     
-    private func launch(with key: String, _ result: @escaping FlutterResult) {
-        Qonversion.launch(withKey: key) { uid in
-            result(uid)
-        }
-    }
-    
-    private func launch(with key: String, userID: String, _ result: @escaping FlutterResult) {
-        Qonversion.launch(withKey: key, userID: userID)
-        
-        result(nil)
-    }
-    
-    private func launch(with key: String, autoTrackPurchases: Bool, _ result: @escaping FlutterResult) {
-        Qonversion.launch(withKey: key, autoTrackPurchases: autoTrackPurchases) { uid in
-            result(uid)
-        }
-    }
-    
     private func addAttributionData(args: [String: Any], _ result: @escaping FlutterResult) {
         guard let data = args["data"] as? [AnyHashable: Any] else {
             result(FlutterError.noData)
@@ -92,6 +55,11 @@ public class SwiftQonversionFlutterSdkPlugin: NSObject, FlutterPlugin {
         
         guard let provider = args["provider"] as? String else {
             result(FlutterError.noProvider)
+            return
+        }
+        
+        guard let userId = args["userId"] as? String else {
+            result(FlutterError.noUserId)
             return
         }
         
@@ -105,7 +73,7 @@ public class SwiftQonversionFlutterSdkPlugin: NSObject, FlutterPlugin {
             break
         }
         
-        Qonversion.addAttributionData(data, from: castedProvider)
+        Qonversion.addAttributionData(data, from: castedProvider, userID: userId)
         
         result(nil)
     }

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,8 +1,7 @@
 class Constants {
   // Params names
   static const kApiKey = 'key';
-  static const kUserId = 'userID';
-  static const kAutoTrackPurchases = 'autoTrackPurchases';
+  static const kUserId = 'userId';
   static const kData = 'data';
   static const kProvider = 'provider';
   static const kDetails = 'details';
@@ -10,10 +9,6 @@ class Constants {
 
   // MethodChannel methods names
   static const mLaunch = 'launch';
-  static const mLaunchWithKeyCompletion = 'launchWithKeyCompletion';
-  static const mLaunchWithKeyUserId = 'launchWithKeyUserId';
-  static const mLaunchWithKeyAutoTrackPurchasesCompletion =
-      'launchWithKeyAutoTrackPurchasesCompletion';
   static const mAddAttributionData = 'addAttributionData';
   static const mTrackPurchase = 'trackPurchase';
 }

--- a/lib/src/qonversion.dart
+++ b/lib/src/qonversion.dart
@@ -66,12 +66,16 @@ class Qonversion {
 
   /// Sends your attribution [data] to the [provider].
   ///
-  /// [userID], if specified, will also be sent to the provider
+  /// [userId], if specified, will also be sent to the provider
   static Future<void> addAttributionData(
-      Map<dynamic, dynamic> data, QAttributionProvider provider) {
+    Map<dynamic, dynamic> data, {
+    @required QAttributionProvider provider,
+    String userId,
+  }) {
     final args = {
       Constants.kData: data,
       Constants.kProvider: describeEnum(provider),
+      Constants.kUserId: userId,
     };
 
     return _channel.invokeMethod(Constants.mAddAttributionData, args);

--- a/lib/src/qonversion.dart
+++ b/lib/src/qonversion.dart
@@ -66,11 +66,14 @@ class Qonversion {
 
   /// Sends your attribution [data] to the [provider].
   ///
-  /// [userId], if specified, will also be sent to the provider
+  /// [userId], if specified, will also be sent to the provider.
+  /// Note that you can pass `null` as [userId] on iOS.
+  ///
+  /// On Android [userId] is non-nullable.
   static Future<void> addAttributionData(
     Map<dynamic, dynamic> data, {
     @required QAttributionProvider provider,
-    String userId,
+    @required String userId,
   }) {
     final args = {
       Constants.kData: data,


### PR DESCRIPTION
* Add `attribution` method support for Android
* Remove deprecated methods on both iOS & Android sides
* Use deprecated `addAttributionData` method on iOS side in order to migrate on new methods on both platforms simultaneously