### PR TITLE
Single API Key initialize method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.0
 
-* API update: new `launch` method with just one API key argument for both platforms; remove old `launch` method; remove all old `launch...` methods.
+* API update: new `launch` method with just one API key argument for both platforms. Contact us at hi@qonversion.io to merge your old API keys into one, [we can do it now](https://qonversion.io/docs/crossplatform-project).
+* API update: Remove old `launch` method; remove all old `launch...` methods.
 * Add `trackPurchase` method to track Android purchases manually.
 * Add `addAttributionData` method implementation for Android.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0
+
+* API update: new `initialize` method with just one API key argument for both platforms; deprecate `launch` method; remove all old `launch...` methods.
+* Add `trackPurchase` method to track Android purchases manually.
+* Add `addAttributionData` method implementation for Android.
+
 ## 0.3.0
 
 * API update: new `launch` method, deprecate all old `launch...` methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.0
 
-* API update: new `initialize` method with just one API key argument for both platforms; deprecate `launch` method; remove all old `launch...` methods.
+* API update: new `launch` method with just one API key argument for both platforms; remove old `launch` method; remove all old `launch...` methods.
 * Add `trackPurchase` method to track Android purchases manually.
 * Add `addAttributionData` method implementation for Android.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ void initState() {
 }
 
 Future<String> _launchQonversion() async {
-  _qonversionUserId = await Qonversion.initialize('YOUR_API_KEY');
+  _qonversionUserId = await Qonversion.launch('YOUR_API_KEY');
 }
 
 ...
@@ -61,7 +61,7 @@ You can also specify your client side `userId` (instead of Qonversion user-id) t
 
 ```
 final userId = 'CLIENT_SIDE_USER_ID';
-Qonversion.initialize(
+Qonversion.launch(
   'YOUR_API_KEY',
   userId: userId,
 );

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ dependencies:
 Run `flutter pub get` to install dependency.
 
 ## Usage 
+
+### Setup
+
 You need to configure Qonversion once at a starting point of your app. 
 
 For example, launch Qonversion in `initState` of your top level widget: 
@@ -42,26 +45,40 @@ void initState() {
 }
 
 Future<String> _launchQonversion() async {
-  _qonversionUserId = await Qonversion.launch(
-    iosApiKey: 'YOUR_IOS_API_KEY',
-    androidApiKey: 'YOUR_ANDROID_API_KEY',
-  );
+  _qonversionUserId = await Qonversion.initialize('YOUR_API_KEY');
 }
 
 ...
 ```
 
-Qonversion will track purchases automatically.
+**IMPORTANT**
+
+On Android you must call `Qonversion.trackPurchase(skuDetails, purchase)` method on each purchase success in order to track purchases.
+
+On iOS Qonversion will track purchases automatically.
 
 You can also specify your client side `userId` (instead of Qonversion user-id) that will be used for matching data in the third party data:
 
 ```
 final userId = 'CLIENT_SIDE_USER_ID';
-Qonversion.launch(
-  iosApiKey: 'YOUR_IOS_API_KEY',
-  androidApiKey: 'YOUR_ANDROID_API_KEY',
+Qonversion.initialize(
+  'YOUR_API_KEY',
   userId: userId,
 );
+```
+
+### Attribution
+You need to have AppsFlyer SDK integrated in your app before starting with this integration. If you do not have Appsflyer integration yet, please use [this docs](https://pub.dev/packages/appsflyer_sdk#-readme-tab-). 
+
+On iOS you can also use Branch integration. 
+
+Use `addAttributionData(data, provider, userId)` method to pass attribution data dictionary: 
+```
+Qonversion.addAttributionData(
+  data, 
+  QAttributionProvider.appsFlyer,
+  'USER_ID',
+)
 ```
 
 ## License

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,7 +22,7 @@ class _MyAppState extends State<MyApp> {
   Future<void> initPlatformState() async {
     String uid;
     try {
-      uid = await Qonversion.initialize('');
+      uid = await Qonversion.launch('');
       print(uid);
     } catch (e) {
       print('Failed to obtain uid from Qonversion.');

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,10 +22,7 @@ class _MyAppState extends State<MyApp> {
   Future<void> initPlatformState() async {
     String uid;
     try {
-      uid = await Qonversion.launch(
-        iosApiKey: '',
-        androidApiKey: '',
-      );
+      uid = await Qonversion.initialize('');
       print(uid);
     } catch (e) {
       print('Failed to obtain uid from Qonversion.');

--- a/lib/src/qonversion.dart
+++ b/lib/src/qonversion.dart
@@ -8,8 +8,37 @@ import 'constants.dart';
 import 'qa_provider.dart';
 
 class Qonversion {
-  static const MethodChannel _channel =
-      const MethodChannel('qonversion_flutter_sdk');
+  static const MethodChannel _channel = MethodChannel('qonversion_flutter_sdk');
+
+  /// **Warning**:
+  /// On Android you will have to call `Qonversion.trackPurchase(details, purchase)` method to track all
+  /// purchases manually.
+  ///
+  /// On iOS Qonversion will track any purchase events (trials, subscriptions, basic purchases) automatically.
+  ///
+  /// ================
+  ///
+  /// Initializes Qonversion SDK with the given API key.
+  /// You can get one in your account on qonversion.io.
+  /// If you're using different API keys for iOS and Android, please
+  /// contact us at hi@qonversion.io since we [now can merge them into one](https://headwayapp.co/qonversion-io-changelog/single-project-for-ios-and-android-platforms-156926).
+  ///
+  /// You can provide your own client-side [userId] if needed.
+  ///
+  /// Returns `userId` for Ads integrations.
+  static Future<String> initialize(
+    String apiKey, {
+    String userId,
+  }) async {
+    final args = {
+      Constants.kApiKey: apiKey,
+      Constants.kUserId: userId,
+    };
+
+    final uid = await _channel.invokeMethod(Constants.mLaunch, args);
+
+    return uid;
+  }
 
   /// Launches Qonversion SDK with the given API keys for each platform:
   /// [androidApiKey] and [iosApiKey] respectively,
@@ -22,6 +51,7 @@ class Qonversion {
   ///
   /// On Android you will have to call `Qonversion.trackPurchase(details, purchase)` method to track all
   /// purchases manually.
+  @Deprecated('Use Qonversion.initialize with just one API key instead')
   static Future<String> launch({
     @required String androidApiKey,
     @required String iosApiKey,

--- a/lib/src/qonversion.dart
+++ b/lib/src/qonversion.dart
@@ -26,42 +26,10 @@ class Qonversion {
   /// You can provide your own client-side [userId] if needed.
   ///
   /// Returns `userId` for Ads integrations.
-  static Future<String> initialize(
+  static Future<String> launch(
     String apiKey, {
     String userId,
   }) async {
-    final args = {
-      Constants.kApiKey: apiKey,
-      Constants.kUserId: userId,
-    };
-
-    final uid = await _channel.invokeMethod(Constants.mLaunch, args);
-
-    return uid;
-  }
-
-  /// Launches Qonversion SDK with the given API keys for each platform:
-  /// [androidApiKey] and [iosApiKey] respectively,
-  /// you can get one in your account on qonversion.io.
-  ///
-  /// Returns `userId` for Ads integrations.
-  ///
-  /// **Warning**:
-  /// On iOS Qonversion will track any purchase events (trials, subscriptions, basic purchases) automatically.
-  ///
-  /// On Android you will have to call `Qonversion.trackPurchase(details, purchase)` method to track all
-  /// purchases manually.
-  @Deprecated('Use Qonversion.initialize with just one API key instead')
-  static Future<String> launch({
-    @required String androidApiKey,
-    @required String iosApiKey,
-    String userId,
-  }) async {
-    final apiKey = _obtainPlatformApiKey(
-      androidApiKey: androidApiKey,
-      iosApiKey: iosApiKey,
-    );
-
     final args = {
       Constants.kApiKey: apiKey,
       Constants.kUserId: userId,
@@ -112,27 +80,5 @@ class Qonversion {
     };
 
     return _channel.invokeMethod(Constants.mAddAttributionData, args);
-  }
-
-  static String _obtainPlatformApiKey({
-    String androidApiKey,
-    String iosApiKey,
-  }) {
-    String key;
-
-    if (Platform.isAndroid) {
-      key = androidApiKey;
-    } else if (Platform.isIOS) {
-      key = iosApiKey;
-    } else {
-      throw Exception('Unsupported platform');
-    }
-
-    if (key == null) {
-      throw Exception(
-          'Please provide API key for the platform you are running an app on');
-    }
-
-    return key;
   }
 }

--- a/lib/src/qonversion.dart
+++ b/lib/src/qonversion.dart
@@ -21,7 +21,7 @@ class Qonversion {
   /// Initializes Qonversion SDK with the given API key.
   /// You can get one in your account on qonversion.io.
   /// If you're using different API keys for iOS and Android, please
-  /// contact us at hi@qonversion.io since we [now can merge them into one](https://headwayapp.co/qonversion-io-changelog/single-project-for-ios-and-android-platforms-156926).
+  /// contact us at hi@qonversion.io since we [now can merge them into one](https://qonversion.io/docs/crossplatform-project).
   ///
   /// You can provide your own client-side [userId] if needed.
   ///


### PR DESCRIPTION
* Add `initialize` method with single API key argument for both platforms since [we can merge different keys into one](https://headwayapp.co/qonversion-io-changelog/single-project-for-ios-and-android-platforms-156926)