### PR TITLE
Downgrade Qonversion Android to ver. 1.0.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.qonversion.android.sdk:sdk:1.0.5"
+    implementation "com.qonversion.android.sdk:sdk:1.0.4"
 }


### PR DESCRIPTION
In order to use Billing Library <3.0 since it has some breaking changes relative to Flutter [in_app_purchase](https://pub.dev/packages/in_app_purchase library).