### PR TITLE
Better Android Manual Purchase Tracking

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,8 @@
-import 'package:flutter/material.dart';
 import 'dart:async';
 
+import 'package:flutter/material.dart';
+import 'package:in_app_purchase/billing_client_wrappers.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
 import 'package:qonversion_flutter/qonversion_flutter.dart';
 
 void main() => runApp(MyApp());
@@ -22,7 +24,7 @@ class _MyAppState extends State<MyApp> {
   Future<void> initPlatformState() async {
     String uid;
     try {
-      uid = await Qonversion.launch('');
+      uid = await Qonversion.launch('2GDfAtgresyVOLHx1PfWQogIP1-FKOVb');
       print(uid);
     } catch (e) {
       print('Failed to obtain uid from Qonversion.');
@@ -42,12 +44,69 @@ class _MyAppState extends State<MyApp> {
           title: const Text('Qonversion example app'),
         ),
         body: Center(
-          child: Text(
-            'Qonversion uid: \n$_uid\n',
-            textAlign: TextAlign.center,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                'Qonversion uid: \n$_uid\n',
+                textAlign: TextAlign.center,
+              ),
+              FlatButton(
+                child: Text('Track'),
+                color: Colors.blue,
+                textColor: Colors.white,
+                onPressed: () async {
+                  final uid = await Qonversion.manualTrackPurchase(
+                      getProductDetails(), getPurchaseDetails());
+                  print(uid);
+                },
+              ),
+            ],
           ),
         ),
       ),
     );
+  }
+
+  ProductDetails getProductDetails() {
+    // ignore: invalid_use_of_visible_for_testing_member
+    final original = SkuDetailsWrapper(
+      description: 'description',
+      freeTrialPeriod: 'freeTrialPeriod',
+      introductoryPrice: 'introductoryPrice',
+      introductoryPriceMicros: 'introductoryPriceMicros',
+      introductoryPriceCycles: 'introductoryPriceCycles',
+      introductoryPricePeriod: 'introductoryPricePeriod',
+      price: 'price',
+      priceAmountMicros: 1000,
+      priceCurrencyCode: 'priceCurrencyCode',
+      sku: 'sku',
+      subscriptionPeriod: 'subscriptionPeriod',
+      title: 'title',
+      type: SkuType.inapp,
+      isRewarded: true,
+      originalPrice: 'originalPrice',
+      originalPriceAmountMicros: 1000,
+    );
+    return ProductDetails.fromSkuDetails(original);
+  }
+
+  PurchaseDetails getPurchaseDetails() {
+    // ignore: invalid_use_of_visible_for_testing_member
+    final original = PurchaseWrapper(
+      orderId: 'orderId',
+      packageName: 'packageName',
+      purchaseTime: 0,
+      signature: 'signature',
+      sku: 'sku',
+      purchaseToken: 'purchaseToken',
+      isAutoRenewing: false,
+      originalJson: '{}',
+      developerPayload: 'dummyPayload',
+      isAcknowledged: true,
+      purchaseState: PurchaseStateWrapper.purchased,
+    );
+
+    return PurchaseDetails.fromPurchase(original);
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
+  in_app_purchase: ^0.3.4+8
 
 dev_dependencies:
   flutter_test:

--- a/lib/qonversion.dart
+++ b/lib/qonversion.dart
@@ -1,5 +1,6 @@
 // This file exists to support old way to import package: 'package:qonversion_flutter/qonversion.dart'.
-// Recommended way to import package no: 'package:qonversion_flutter/qonversion_flutter.dart'.
+// Recommended way to import package now is: 'package:qonversion_flutter/qonversion_flutter.dart'.
 
-export 'src/qonversion.dart';
 export 'src/qa_provider.dart';
+export 'src/qonversion.dart';
+export 'src/serializer.dart';

--- a/lib/qonversion_flutter.dart
+++ b/lib/qonversion_flutter.dart
@@ -1,2 +1,3 @@
-export 'src/qonversion.dart';
 export 'src/qa_provider.dart';
+export 'src/qonversion.dart';
+export 'src/serializer.dart';

--- a/lib/src/serializer.dart
+++ b/lib/src/serializer.dart
@@ -1,0 +1,47 @@
+import 'package:in_app_purchase/billing_client_wrappers.dart';
+
+class QDetailsSerializer {
+  /// Returns [Map] from billing client's [SkuDetailsWrapper]
+  static Map<String, dynamic> buildSkuMap(SkuDetailsWrapper original) {
+    return <String, dynamic>{
+      'description': original.description,
+      'freeTrialPeriod': original.freeTrialPeriod,
+      'introductoryPrice': original.introductoryPrice,
+      'introductoryPriceMicros': original.introductoryPriceMicros,
+      'introductoryPriceCycles': original.introductoryPriceCycles,
+      'introductoryPricePeriod': original.introductoryPricePeriod,
+      'price': original.price,
+      'priceAmountMicros': original.priceAmountMicros,
+      'priceCurrencyCode': original.priceCurrencyCode,
+      'sku': original.sku,
+      'subscriptionPeriod': original.subscriptionPeriod,
+      'title': original.title,
+      'type': original.type.toString().substring(8),
+      'isRewarded': original.isRewarded,
+      'originalPrice': original.originalPrice,
+      'originalPriceAmountMicros': original.originalPriceAmountMicros,
+    };
+  }
+
+  /// Returns [Map] from billing client's [PurchaseWrapper]
+  static Map<String, dynamic> buildPurchaseMap(PurchaseWrapper original) {
+    const _purchaseStateWrapperEnumMap = {
+      PurchaseStateWrapper.unspecified_state: 0,
+      PurchaseStateWrapper.purchased: 1,
+      PurchaseStateWrapper.pending: 2,
+    };
+    return <String, dynamic>{
+      'orderId': original.orderId,
+      'packageName': original.packageName,
+      'purchaseTime': original.purchaseTime,
+      'signature': original.signature,
+      'sku': original.sku,
+      'purchaseToken': original.purchaseToken,
+      'isAutoRenewing': original.isAutoRenewing,
+      'originalJson': original.originalJson,
+      'developerPayload': original.developerPayload,
+      'purchaseState': _purchaseStateWrapperEnumMap[original.purchaseState],
+      'isAcknowledged': original.isAcknowledged,
+    };
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -60,6 +60,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  in_app_purchase:
+    dependency: "direct main"
+    description:
+      name: in_app_purchase
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.4+8"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
@@ -144,4 +158,4 @@ packages:
     version: "2.0.8"
 sdks:
   dart: ">=2.9.0-14.0.dev <3.0.0"
-  flutter: ">=1.10.0 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  in_app_purchase: ^0.3.4+8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
* Add dependency to `in_app_purchase` plugin since we have to use its APIs anyway
* Add convenint `manualTrackPurchase` method to easily map product and purchase details to JSON and pass it to the platform-side code