### PR TITLE
fix(Qonversion.offerings) - casting error

### DIFF
--- a/lib/src/models/utils/mapper.dart
+++ b/lib/src/models/utils/mapper.dart
@@ -1,3 +1,7 @@
+import 'dart:convert';
+
+import '../eligibility.dart';
+import '../offerings.dart';
 import '../permission.dart';
 import '../product.dart';
 import '../sk_product/discount.dart';
@@ -26,6 +30,23 @@ class QMapper {
       final permissionMap = Map<String, dynamic>.from(value);
       return MapEntry(key, QPermission.fromJson(permissionMap));
     });
+  }
+
+  static QOfferings offeringsFromJson(String? jsonString) {
+    if (jsonString == null) return QOfferings(null, <QOffering>[]);
+
+    final offeringJson = jsonDecode(jsonString);
+
+    return QOfferings.fromJson(offeringJson);
+  }
+
+  static Map<String, QEligibility> eligibilityFromJson(String? jsonString) {
+    if (jsonString == null) return <String, QEligibility>{};
+
+    final eligibilityJson = jsonDecode(jsonString);
+
+    return eligibilityJson
+        .map((key, value) => MapEntry(key, QEligibility.fromJson(value)));
   }
 
   static SKProductWrapper? skProductFromJson(dynamic json) {

--- a/lib/src/models/utils/mapper.dart
+++ b/lib/src/models/utils/mapper.dart
@@ -35,7 +35,7 @@ class QMapper {
   static QOfferings offeringsFromJson(String? jsonString) {
     if (jsonString == null) return QOfferings(null, <QOffering>[]);
 
-    final offeringJson = jsonDecode(jsonString);
+    final offeringJson = Map<String, dynamic>.from(jsonDecode(jsonString));
 
     return QOfferings.fromJson(offeringJson);
   }
@@ -43,7 +43,7 @@ class QMapper {
   static Map<String, QEligibility> eligibilityFromJson(String? jsonString) {
     if (jsonString == null) return <String, QEligibility>{};
 
-    final eligibilityJson = jsonDecode(jsonString);
+    final eligibilityJson = Map<String, dynamic>.from(jsonDecode(jsonString));
 
     return eligibilityJson
         .map((key, value) => MapEntry(key, QEligibility.fromJson(value)));

--- a/lib/src/qonversion.dart
+++ b/lib/src/qonversion.dart
@@ -206,7 +206,7 @@ class Qonversion {
   ///
   /// See [Offerings](https://qonversion.io/docs/offerings) for more details.
   /// See [Product Center](https://qonversion.io/docs/product-center) for more details.
-    static Future<QOfferings> offerings() async {
+  static Future<QOfferings> offerings() async {
     final offeringsString = await _channel.invokeMethod<String>(Constants.mOfferings);
 
     return QMapper.offeringsFromJson(offeringsString);

--- a/lib/src/qonversion.dart
+++ b/lib/src/qonversion.dart
@@ -206,13 +206,10 @@ class Qonversion {
   ///
   /// See [Offerings](https://qonversion.io/docs/offerings) for more details.
   /// See [Product Center](https://qonversion.io/docs/product-center) for more details.
-  static Future<QOfferings> offerings() async {
-    final offeringsString =
-        await (_channel.invokeMethod<String>(Constants.mOfferings) as FutureOr<String>);
+    static Future<QOfferings> offerings() async {
+    final offeringsString = await _channel.invokeMethod<String>(Constants.mOfferings);
 
-    final Map<String, dynamic> decodedOfferings = jsonDecode(offeringsString);
-
-    return QOfferings.fromJson(decodedOfferings);
+    return QMapper.offeringsFromJson(offeringsString);
   }
 
   /// You can check if a user is eligible for an introductory offer, including a free trial.
@@ -220,14 +217,10 @@ class Qonversion {
   /// [ids] products identifiers that must be checked
   static Future<Map<String, QEligibility>> checkTrialIntroEligibility(
       List<String> ids) async {
-    final eligibilitiesString = await (_channel.invokeMethod<String>(
-        Constants.mCheckTrialIntroEligibility, {"ids": ids}) as FutureOr<String>);
+    final eligibilitiesString = await _channel.invokeMethod<String>(
+        Constants.mCheckTrialIntroEligibility, {"ids": ids});
 
-    final Map<String, dynamic> decodedEligibilities =
-        jsonDecode(eligibilitiesString);
-
-    return decodedEligibilities
-        .map((key, value) => MapEntry(key, QEligibility.fromJson(value)));
+    return QMapper.eligibilityFromJson(eligibilitiesString);
   }
 
   // Private methods


### PR DESCRIPTION
Fix for #69 

notes:
- moved the mapping to `QMapper`
- returns an empty object when null.
- Doesn't appear that null will ever be returned from `_channel.invokeMethod` but the null check if there to cater for sound null-safety
- No tests added as the library doesn't have any

Tested:
- empty response from `Constants.mCheckTrialIntroEligibility` ("{}")
- empty response from `Constants.mOfferings`
- full response from `Constants.mOfferings`

Untested:
- full response from `Constants.mCheckTrialIntroEligibility`

