### PR TITLE
Update example app to use deferredPurchaseStream

### DIFF
--- a/example/lib/app_state.dart
+++ b/example/lib/app_state.dart
@@ -28,7 +28,10 @@ class AppState extends ChangeNotifier {
   
   // No-Codes events
   List<String> _noCodesEvents = [];
-  
+
+  // Deferred purchase events (e.g. SCA, Ask to Buy)
+  List<String> _deferredPurchaseEvents = [];
+
   // Getters
   bool get isInitialized => _isInitialized;
   String get initStatus => _initStatus;
@@ -40,6 +43,7 @@ class AppState extends ChangeNotifier {
   QRemoteConfigList? get remoteConfigs => _remoteConfigs;
   QUserProperties? get userProperties => _userProperties;
   List<String> get noCodesEvents => _noCodesEvents;
+  List<String> get deferredPurchaseEvents => _deferredPurchaseEvents;
   
   // Setters with notification
   void setInitStatus(String status) {
@@ -95,6 +99,19 @@ class AppState extends ChangeNotifier {
   
   void clearNoCodesEvents() {
     _noCodesEvents.clear();
+    notifyListeners();
+  }
+
+  void addDeferredPurchaseEvent(String event) {
+    _deferredPurchaseEvents.insert(0, '${DateTime.now().toString().substring(11, 19)}: $event');
+    if (_deferredPurchaseEvents.length > 50) {
+      _deferredPurchaseEvents.removeLast();
+    }
+    notifyListeners();
+  }
+
+  void clearDeferredPurchaseEvents() {
+    _deferredPurchaseEvents.clear();
     notifyListeners();
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -57,14 +57,17 @@ class _QonversionDemoAppState extends State<QonversionDemoApp> {
           .setEntitlementsCacheLifetime(QEntitlementsCacheLifetime.month)
           .build();
       
-      Qonversion.initialize(config);
+      final qonversion = Qonversion.initialize(config);
       debugPrint('✅ [Qonversion] SDK initialized successfully');
-      
+
+      // Subscribe to deferred purchase events (e.g. SCA, Ask to Buy)
+      _subscribeToDeferredPurchases(qonversion, appState);
+
       // Initialize No-Codes
       final noCodesConfig = NoCodesConfigBuilder(projectKey).build();
       final noCodes = NoCodes.initialize(noCodesConfig);
       debugPrint('✅ [NoCodes] SDK initialized successfully');
-      
+
       // Subscribe to No-Codes events
       _subscribeToNoCodesEvents(noCodes, appState);
       
@@ -76,6 +79,18 @@ class _QonversionDemoAppState extends State<QonversionDemoApp> {
       debugPrint('❌ [Qonversion] SDK initialization failed: $e');
       appState.setInitStatus('error');
     }
+  }
+
+  void _subscribeToDeferredPurchases(Qonversion qonversion, AppState appState) {
+    qonversion.deferredPurchaseStream.listen((QPurchaseResult result) {
+      final productId = result.storeTransaction?.productId ?? 'unknown';
+      debugPrint('📡 [Qonversion] Deferred purchase: ${result.status.name} for $productId');
+      appState.addDeferredPurchaseEvent('Deferred purchase ${result.status.name}: $productId');
+
+      if (result.isSuccess && result.entitlements != null) {
+        appState.setEntitlements(result.entitlements);
+      }
+    });
   }
 
   void _subscribeToNoCodesEvents(NoCodes noCodes, AppState appState) {


### PR DESCRIPTION
## Summary
- Subscribe the example app to `Qonversion.deferredPurchaseStream` during SDK initialization, mirroring the existing No-Codes stream subscription pattern in `main.dart`.
- On a successful deferred purchase, refresh entitlements in `AppState` so other screens reflect the new state.
- Track each deferred purchase event in `AppState` (with a clearable history) so future screens can display them if needed.

## Notes
- The example app previously had no `setEntitlementsUpdateListener` usage to migrate from. This PR just adds the new API hookup.
- The stream emits `QPurchaseResult` (not `QDeferredTransaction`) - matching `lib/src/qonversion.dart` and `lib/src/dto/purchase_result.dart`.

## Test plan
- [ ] Build and run the example app on iOS / Android
- [ ] Trigger a deferred purchase (e.g. Ask to Buy / SCA in sandbox)
- [ ] Confirm the debug log prints `Deferred purchase ...` and entitlements update on success