### PR TITLE
Release 11.7.1 (sandwich 7.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.7.1
+* Fix Android crash that could occur when a No-Code screen activity was restored after process death, before the host app had re-run initialization. Fixes #450.
+
 ## 11.7.0
 * // Update changelog here
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "io.qonversion:sandwich:7.9.0"
+    implementation "io.qonversion:sandwich:7.9.1"
     implementation 'com.google.code.gson:gson:2.9.0'
 }

--- a/ios/qonversion_flutter.podspec
+++ b/ios/qonversion_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '13.0'
-  s.dependency "QonversionSandwich", "7.9.0"
+  s.dependency "QonversionSandwich", "7.9.1"
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/macos/qonversion_flutter.podspec
+++ b/macos/qonversion_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
   s.platform = :osx, '10.12'
-  s.dependency "QonversionSandwich", "7.9.0"
+  s.dependency "QonversionSandwich", "7.9.1"
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: qonversion_flutter
 description: Flutter plugin to implement in-app subscriptions and purchases. Validate user receipts and manage cross-platform access to paid content on your app. Android & iOS.
-version: 11.7.0
+version: 11.7.1
 homepage: 'https://qonversion.io'
 repository: 'https://github.com/qonversion/flutter-sdk'
 


### PR DESCRIPTION
## Summary

Bumps flutter-sdk to 11.7.1, pulling in `QonversionSandwich:7.9.1` -> `io.qonversion:no-codes:1.9.2` transitively.

Picks up the process-death restoration crash fix from qonversion/android-sdk#807.

Fixes #450.

## Diff

- `pubspec.yaml`: 11.7.0 -> 11.7.1
- `android/build.gradle`: sandwich 7.9.0 -> 7.9.1
- `ios/qonversion_flutter.podspec`: QonversionSandwich 7.9.0 -> 7.9.1
- `macos/qonversion_flutter.podspec`: QonversionSandwich 7.9.0 -> 7.9.1
- `CHANGELOG.md`: 11.7.1 entry

## Release chain

1. qonversion/android-sdk#807 - the fix (merged, no-codes 1.9.2 published).
2. qonversion/sandwich-sdk#320 - sandwich 7.9.1 (open, paired review).
3. This PR - flutter-sdk 11.7.1 (depends on #320 being merged + sandwich 7.9.1 published to Maven Central + CocoaPods first).

## Test plan

- [ ] CI green on this branch (will fail until sandwich 7.9.1 is published; safe to re-run after)
- [ ] pub.dev publish completes after merge + tag (manual)