### PR TITLE
Bridge No-Codes loadScreen, defaultVariables and custom action event (DEV-1189)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "io.qonversion:sandwich:7.9.0"
+    implementation "io.qonversion:sandwich:7.10.1"
     implementation 'com.google.code.gson:gson:2.9.0'
 }

--- a/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/NoCodesPlugin.kt
+++ b/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/NoCodesPlugin.kt
@@ -20,7 +20,8 @@ class NoCodesPlugin(private val messenger: BinaryMessenger, private val context:
     private var actionFailedEventStreamHandler: BaseEventStreamHandler? = null
     private var actionFinishedEventStreamHandler: BaseEventStreamHandler? = null
     private var screenFailedToLoadEventStreamHandler: BaseEventStreamHandler? = null
-    
+    private var customActionEventStreamHandler: BaseEventStreamHandler? = null
+
     // Purchase delegate event stream handlers
     private var purchaseEventStreamHandler: BaseEventStreamHandler? = null
     private var restoreEventStreamHandler: BaseEventStreamHandler? = null
@@ -32,6 +33,7 @@ class NoCodesPlugin(private val messenger: BinaryMessenger, private val context:
         private const val ACTION_FAILED_EVENT_CHANNEL = "nocodes_action_failed"
         private const val ACTION_FINISHED_EVENT_CHANNEL = "nocodes_action_finished"
         private const val SCREEN_FAILED_TO_LOAD_EVENT_CHANNEL = "nocodes_screen_failed_to_load"
+        private const val CUSTOM_ACTION_EVENT_CHANNEL = "nocodes_custom_action"
         private const val PURCHASE_EVENT_CHANNEL = "nocodes_purchase"
         private const val RESTORE_EVENT_CHANNEL = "nocodes_restore"
     }
@@ -65,6 +67,10 @@ class NoCodesPlugin(private val messenger: BinaryMessenger, private val context:
         val screenFailedToLoadListener = BaseListenerWrapper(messenger, SCREEN_FAILED_TO_LOAD_EVENT_CHANNEL)
         screenFailedToLoadListener.register()
         this.screenFailedToLoadEventStreamHandler = screenFailedToLoadListener.eventStreamHandler
+
+        val customActionListener = BaseListenerWrapper(messenger, CUSTOM_ACTION_EVENT_CHANNEL)
+        customActionListener.register()
+        this.customActionEventStreamHandler = customActionListener.eventStreamHandler
         
         // Register purchase delegate event channels
         val purchaseListener = BaseListenerWrapper(messenger, PURCHASE_EVENT_CHANNEL)
@@ -113,6 +119,14 @@ class NoCodesPlugin(private val messenger: BinaryMessenger, private val context:
         } else {
             result.noNecessaryDataError()
         }
+    }
+
+    fun loadScreen(contextKey: String?, result: Result) {
+        if (contextKey == null) {
+            return result.noNecessaryDataError()
+        }
+        val sandwich = noCodesSandwich ?: return result.noNecessaryDataError()
+        sandwich.loadScreen(contextKey, result.toJsonResultListener())
     }
 
     fun closeNoCodes(result: Result) {
@@ -182,6 +196,9 @@ class NoCodesPlugin(private val messenger: BinaryMessenger, private val context:
             }
             NoCodesEventListener.Event.ScreenFailedToLoad -> {
                 screenFailedToLoadEventStreamHandler?.eventSink?.success(jsonString)
+            }
+            NoCodesEventListener.Event.CustomAction -> {
+                customActionEventStreamHandler?.eventSink?.success(jsonString)
             }
         }
     }

--- a/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/NoCodesPlugin.kt
+++ b/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/NoCodesPlugin.kt
@@ -125,7 +125,8 @@ class NoCodesPlugin(private val messenger: BinaryMessenger, private val context:
         if (contextKey == null) {
             return result.noNecessaryDataError()
         }
-        val sandwich = noCodesSandwich ?: return result.noNecessaryDataError()
+        val sandwich = noCodesSandwich
+            ?: return result.error("SDKInitializationError", "No-Codes SDK is not initialized", null)
         sandwich.loadScreen(contextKey, result.toJsonResultListener())
     }
 

--- a/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionPlugin.kt
+++ b/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionPlugin.kt
@@ -164,6 +164,7 @@ class QonversionPlugin : MethodCallHandler, FlutterPlugin, ActivityAware {
             "setScreenPresentationConfig" -> noCodesPlugin?.setScreenPresentationConfig(args["config"] as? Map<String, Any>, args["contextKey"] as? String, result)
             "showNoCodesScreen" -> noCodesPlugin?.showNoCodesScreen(args["contextKey"] as? String, args["customVariables"] as? Map<String, String>, result)
             "loadNoCodesScreen" -> noCodesPlugin?.loadScreen(args["contextKey"] as? String, result)
+                ?: result.notImplemented()
             "setNoCodesLocale" -> noCodesPlugin?.setLocale(args["locale"] as? String, result)
             "setNoCodesTheme" -> noCodesPlugin?.setTheme(args["theme"] as? String, result)
             // NoCodes Purchase Delegate methods

--- a/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionPlugin.kt
+++ b/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionPlugin.kt
@@ -163,6 +163,7 @@ class QonversionPlugin : MethodCallHandler, FlutterPlugin, ActivityAware {
             "initializeNoCodes" -> noCodesPlugin?.initializeNoCodes(args, result)
             "setScreenPresentationConfig" -> noCodesPlugin?.setScreenPresentationConfig(args["config"] as? Map<String, Any>, args["contextKey"] as? String, result)
             "showNoCodesScreen" -> noCodesPlugin?.showNoCodesScreen(args["contextKey"] as? String, args["customVariables"] as? Map<String, String>, result)
+            "loadNoCodesScreen" -> noCodesPlugin?.loadScreen(args["contextKey"] as? String, result)
             "setNoCodesLocale" -> noCodesPlugin?.setLocale(args["locale"] as? String, result)
             "setNoCodesTheme" -> noCodesPlugin?.setTheme(args["theme"] as? String, result)
             // NoCodes Purchase Delegate methods

--- a/ios/Classes/NoCodesPlugin.swift
+++ b/ios/Classes/NoCodesPlugin.swift
@@ -18,6 +18,7 @@ public class NoCodesPlugin: NSObject {
     private let eventActionFailed = "nocodes_action_failed"
     private let eventActionFinished = "nocodes_action_finished"
     private let eventScreenFailedToLoad = "nocodes_screen_failed_to_load"
+    private let eventCustomAction = "nocodes_custom_action"
     private let eventPurchase = "nocodes_purchase"
     private let eventRestore = "nocodes_restore"
     
@@ -27,6 +28,7 @@ public class NoCodesPlugin: NSObject {
     private var actionFailedEventStreamHandler: BaseEventStreamHandler?
     private var actionFinishedEventStreamHandler: BaseEventStreamHandler?
     private var screenFailedToLoadEventStreamHandler: BaseEventStreamHandler?
+    private var customActionEventStreamHandler: BaseEventStreamHandler?
     private var purchaseEventStreamHandler: BaseEventStreamHandler?
     private var restoreEventStreamHandler: BaseEventStreamHandler?
     
@@ -63,6 +65,11 @@ public class NoCodesPlugin: NSObject {
         let screenFailedToLoadListener = FlutterListenerWrapper<BaseEventStreamHandler>(registrar, postfix: eventScreenFailedToLoad)
         screenFailedToLoadListener.register() { eventStreamHandler in
             self.screenFailedToLoadEventStreamHandler = eventStreamHandler
+        }
+
+        let customActionListener = FlutterListenerWrapper<BaseEventStreamHandler>(registrar, postfix: eventCustomAction)
+        customActionListener.register() { eventStreamHandler in
+            self.customActionEventStreamHandler = eventStreamHandler
         }
         
         // Register purchase delegate event channels
@@ -119,6 +126,31 @@ public class NoCodesPlugin: NSObject {
         result(nil)
     }
     
+    @MainActor public func loadScreen(_ args: [String: Any]?, _ result: @escaping FlutterResult) {
+        guard let args = args,
+              let contextKey = args["contextKey"] as? String else {
+            return result(FlutterError.noNecessaryData)
+        }
+
+        guard let noCodesSandwich = noCodesSandwich else {
+            return result(FlutterError.noNecessaryData)
+        }
+
+        noCodesSandwich.loadScreen(contextKey) { data, error in
+            if let error = error {
+                return result(FlutterError.sandwichError(error))
+            }
+
+            guard let data = data,
+                  let jsonData = try? JSONSerialization.data(withJSONObject: data),
+                  let jsonString = String(data: jsonData, encoding: .utf8) else {
+                return result(FlutterError.serializationError)
+            }
+
+            result(jsonString)
+        }
+    }
+
     @MainActor public func close(_ result: @escaping FlutterResult) {
         noCodesSandwich?.close()
         result(nil)
@@ -197,7 +229,10 @@ extension NoCodesPlugin: NoCodesEventListener {
                 
             case self.eventScreenFailedToLoad:
                 self.screenFailedToLoadEventStreamHandler?.eventSink?(jsonString)
-                
+
+            case self.eventCustomAction:
+                self.customActionEventStreamHandler?.eventSink?(jsonString)
+
             default:
                 print("NoCodesPlugin: unknown event type: \(event)")
             }

--- a/ios/Classes/NoCodesPlugin.swift
+++ b/ios/Classes/NoCodesPlugin.swift
@@ -133,7 +133,9 @@ public class NoCodesPlugin: NSObject {
         }
 
         guard let noCodesSandwich = noCodesSandwich else {
-            return result(FlutterError.noNecessaryData)
+            return result(FlutterError(code: "SDKInitializationError",
+                                       message: "No-Codes SDK is not initialized",
+                                       details: nil))
         }
 
         noCodesSandwich.loadScreen(contextKey) { data, error in

--- a/ios/Classes/SwiftQonversionPlugin.swift
+++ b/ios/Classes/SwiftQonversionPlugin.swift
@@ -190,7 +190,11 @@ public class SwiftQonversionPlugin: NSObject, FlutterPlugin {
       return
 
     case "loadNoCodesScreen":
-      noCodesPlugin?.loadScreen(args, result)
+      if let noCodesPlugin = noCodesPlugin {
+        noCodesPlugin.loadScreen(args, result)
+      } else {
+        result(FlutterMethodNotImplemented)
+      }
       return
 
     case "setNoCodesLocale":

--- a/ios/Classes/SwiftQonversionPlugin.swift
+++ b/ios/Classes/SwiftQonversionPlugin.swift
@@ -188,7 +188,11 @@ public class SwiftQonversionPlugin: NSObject, FlutterPlugin {
     case "showNoCodesScreen":
       noCodesPlugin?.showScreen(args, result)
       return
-      
+
+    case "loadNoCodesScreen":
+      noCodesPlugin?.loadScreen(args, result)
+      return
+
     case "setNoCodesLocale":
       noCodesPlugin?.setLocale(args["locale"] as? String, result)
       return

--- a/ios/qonversion_flutter.podspec
+++ b/ios/qonversion_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '13.0'
-  s.dependency "QonversionSandwich", "7.9.0"
+  s.dependency "QonversionSandwich", "7.10.1"
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/lib/qonversion_flutter.dart
+++ b/lib/qonversion_flutter.dart
@@ -8,6 +8,7 @@ export 'src/dto/entitlements_cache_lifetime.dart';
 export 'src/dto/environment.dart';
 export 'src/dto/launch_mode.dart';
 export 'src/dto/nocodes_events.dart';
+export 'src/dto/nocodes_screen.dart';
 export 'src/dto/nocodes_theme.dart';
 export 'src/dto/offerings.dart';
 export 'src/dto/presentation_config.dart';

--- a/lib/src/dto/nocodes_events.dart
+++ b/lib/src/dto/nocodes_events.dart
@@ -151,4 +151,35 @@ class NoCodesScreenFailedToLoadEvent extends NoCodesEvent {
   String toString() {
     return 'NoCodesScreenFailedToLoadEvent(payload: $payload)';
   }
+}
+
+/// Event when a custom action configured in the builder is triggered on the screen.
+/// The No-Codes SDK does not execute anything itself — handle [value] in your app code.
+/// The screen stays open; close it using [NoCodes.close] if needed.
+class NoCodesCustomActionEvent extends NoCodesEvent {
+  final Map<String, dynamic>? payload;
+
+  const NoCodesCustomActionEvent({this.payload});
+
+  /// The string value configured for the custom action in the builder,
+  /// or an empty string if no value was configured.
+  String get value => payload?['value'] as String? ?? '';
+
+  factory NoCodesCustomActionEvent.fromMap(Map<String, dynamic> map) {
+    return NoCodesCustomActionEvent(
+      payload: map['payload'] as Map<String, dynamic>?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'type': 'nocodes_custom_action',
+      'payload': payload,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'NoCodesCustomActionEvent(payload: $payload)';
+  }
 } 

--- a/lib/src/dto/nocodes_screen.dart
+++ b/lib/src/dto/nocodes_screen.dart
@@ -44,7 +44,8 @@ class QScreenVariable {
   /// Authored value type: `"boolean"`, `"string"` or `"number"`.
   final String type;
 
-  /// The configured default value, preserving its native type.
+  /// The configured default value, preserving its native type
+  /// (bool / String / double). Numbers are always [double].
   /// Null when no default value was authored.
   final Object? value;
 
@@ -62,11 +63,15 @@ class QScreenVariable {
   });
 
   factory QScreenVariable.fromMap(Map<String, dynamic> map) {
+    final rawValue = map['value'];
+    // The Android bridge serializes numbers as double while iOS emits integral
+    // numbers as int — normalize so numeric values always come as double.
+    final value = rawValue is int ? rawValue.toDouble() : rawValue;
     return QScreenVariable(
       kind: _screenVariableKindFromKey(map['kind'] as String?),
       key: map['key'] as String? ?? '',
       type: map['type'] as String? ?? '',
-      value: map['value'],
+      value: value,
       stringValue: map['stringValue'] as String? ?? '',
     );
   }

--- a/lib/src/dto/nocodes_screen.dart
+++ b/lib/src/dto/nocodes_screen.dart
@@ -1,0 +1,142 @@
+/// Kind of a No-Codes screen default variable — what it was configured as in the builder.
+/// The set may grow in future backend versions; values this SDK version does not know
+/// are mapped to [QScreenVariableKind.unknown] instead of failing.
+enum QScreenVariableKind {
+  /// A Screen Variable authored in the builder's Variables section.
+  custom,
+
+  /// A product slot: the variable key is the slot name and the value is the default
+  /// Qonversion product id assigned to it.
+  product,
+
+  /// The screen's Default Product configured in the builder: the value is
+  /// the Qonversion product id selected by default.
+  selectedProduct,
+
+  /// A kind introduced on the backend after this SDK version was released.
+  unknown,
+}
+
+QScreenVariableKind _screenVariableKindFromKey(String? key) {
+  switch (key) {
+    case 'custom':
+      return QScreenVariableKind.custom;
+    case 'product':
+      return QScreenVariableKind.product;
+    case 'selected_product':
+      return QScreenVariableKind.selectedProduct;
+    default:
+      return QScreenVariableKind.unknown;
+  }
+}
+
+/// A typed default variable of a No-Codes screen, configured in the builder and delivered
+/// at screen load so it can be read by key. The value keeps its authored type
+/// (bool / String / num) rather than being coerced to a string.
+class QScreenVariable {
+  /// What the variable represents — see [QScreenVariableKind].
+  final QScreenVariableKind kind;
+
+  /// Variable name it is addressed by (`variable.<key>` in the builder for custom
+  /// variables, the slot name for product slots). May contain spaces.
+  final String key;
+
+  /// Authored value type: `"boolean"`, `"string"` or `"number"`.
+  final String type;
+
+  /// The configured default value, preserving its native type.
+  /// Null when no default value was authored.
+  final Object? value;
+
+  /// The value rendered as a plain string regardless of its native type: `"true"`/`"false"`
+  /// for booleans, the string itself, a number without a trailing `.0` when integral,
+  /// or an empty string when no value was authored.
+  final String stringValue;
+
+  const QScreenVariable({
+    required this.kind,
+    required this.key,
+    required this.type,
+    required this.value,
+    required this.stringValue,
+  });
+
+  factory QScreenVariable.fromMap(Map<String, dynamic> map) {
+    return QScreenVariable(
+      kind: _screenVariableKindFromKey(map['kind'] as String?),
+      key: map['key'] as String? ?? '',
+      type: map['type'] as String? ?? '',
+      value: map['value'],
+      stringValue: map['stringValue'] as String? ?? '',
+    );
+  }
+
+  @override
+  String toString() {
+    return 'QScreenVariable(kind: $kind, key: $key, type: $type, value: $value, stringValue: $stringValue)';
+  }
+}
+
+/// A loaded No-Codes screen returned from [NoCodes.loadScreen].
+///
+/// Exposes the screen identifiers and the typed default variables configured in the builder —
+/// the screen content stays internal, as rendering remains the SDK's job via
+/// [NoCodes.showScreen].
+class QNoCodeScreen {
+  /// Identifier of the screen.
+  final String id;
+
+  /// The context key of the screen set in the No-Codes builder.
+  final String contextKey;
+
+  /// The Qonversion product id selected by default when the screen opens (the builder's
+  /// Default Product), or null when none is configured.
+  final String? defaultSelectedProductId;
+
+  /// Typed default variables of the screen configured in the builder: authored custom
+  /// variables and product slots. Read them by [QScreenVariable.key] (may be empty).
+  final List<QScreenVariable> defaultVariables;
+
+  const QNoCodeScreen({
+    required this.id,
+    required this.contextKey,
+    this.defaultSelectedProductId,
+    this.defaultVariables = const [],
+  });
+
+  factory QNoCodeScreen.fromMap(Map<String, dynamic> map) {
+    final rawVariables = map['defaultVariables'] as List<dynamic>? ?? [];
+    return QNoCodeScreen(
+      id: map['id'] as String? ?? '',
+      contextKey: map['contextKey'] as String? ?? '',
+      defaultSelectedProductId: map['defaultSelectedProductId'] as String?,
+      defaultVariables: rawVariables
+          .whereType<Map<dynamic, dynamic>>()
+          .map((variable) => QScreenVariable.fromMap(Map<String, dynamic>.from(variable)))
+          .toList(),
+    );
+  }
+
+  /// Returns the default variable configured under the given [key], or null when the screen
+  /// has no variable with that exact (case-sensitive) key.
+  ///
+  /// Keys are only unique within a kind — a custom variable and a product slot may share
+  /// a name — so pass [kind] to disambiguate; without it the first match in payload order
+  /// (custom variables, then product slots, then the selected product) is returned.
+  ///
+  /// For the default selected product prefer [defaultSelectedProductId] — it needs no key.
+  QScreenVariable? defaultVariable(String key, {QScreenVariableKind? kind}) {
+    for (final variable in defaultVariables) {
+      if (variable.key == key && (kind == null || variable.kind == kind)) {
+        return variable;
+      }
+    }
+    return null;
+  }
+
+  @override
+  String toString() {
+    return 'QNoCodeScreen(id: $id, contextKey: $contextKey, '
+        'defaultSelectedProductId: $defaultSelectedProductId, defaultVariables: $defaultVariables)';
+  }
+}

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -80,6 +80,7 @@ class Constants {
   static const mInitializeNoCodes = 'initializeNoCodes';
   static const mSetScreenPresentationConfig = 'setScreenPresentationConfig';
   static const mShowNoCodesScreen = 'showNoCodesScreen';
+  static const mLoadNoCodesScreen = 'loadNoCodesScreen';
   static const mCloseNoCodes = 'closeNoCodes';
   static const mSetNoCodesLocale = 'setNoCodesLocale';
   static const mSetNoCodesTheme = 'setNoCodesTheme';

--- a/lib/src/internal/nocodes_internal.dart
+++ b/lib/src/internal/nocodes_internal.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:qonversion_flutter/src/dto/qonversion_exception.dart';
 import 'package:qonversion_flutter/src/internal/qonversion_internal.dart';
 import '../dto/nocodes_events.dart';
+import '../dto/nocodes_screen.dart';
 import '../dto/presentation_config.dart';
 import '../dto/product.dart';
 import '../dto/nocodes_theme.dart';
@@ -24,6 +25,7 @@ class NoCodesInternal implements NoCodes {
   final EventChannel _actionFailedEventChannel = EventChannel('qonversion_flutter_nocodes_action_failed');
   final EventChannel _actionFinishedEventChannel = EventChannel('qonversion_flutter_nocodes_action_finished');
   final EventChannel _screenFailedToLoadEventChannel = EventChannel('qonversion_flutter_nocodes_screen_failed_to_load');
+  final EventChannel _customActionEventChannel = EventChannel('qonversion_flutter_nocodes_custom_action');
   
   // Event channels for purchase delegate
   final EventChannel _purchaseEventChannel = EventChannel('qonversion_flutter_nocodes_purchase');
@@ -151,6 +153,20 @@ class NoCodesInternal implements NoCodes {
   }
 
   @override
+  Stream<NoCodesCustomActionEvent> get customActionStream {
+    if (Platform.isMacOS) {
+      return Stream.empty();
+    }
+    return _customActionEventChannel
+        .receiveBroadcastStream()
+        .cast<String>()
+        .map((event) {
+      final Map<String, dynamic> decodedEvent = jsonDecode(event);
+      return NoCodesCustomActionEvent.fromMap(decodedEvent);
+    });
+  }
+
+  @override
   Future<void> setScreenPresentationConfig(
     NoCodesPresentationConfig config, {
     String? contextKey,
@@ -177,6 +193,22 @@ class NoCodesInternal implements NoCodes {
       if (customVariables != null) Constants.kCustomVariables: customVariables,
     };
     await _invokeMethod(Constants.mShowNoCodesScreen, args);
+  }
+
+  @override
+  Future<QNoCodeScreen> loadScreen(String contextKey) async {
+    if (Platform.isMacOS) {
+      throw QonversionException(
+        'MacOSNotSupported',
+        'No-Codes is not supported on macOS',
+        null,
+      );
+    }
+
+    final args = {Constants.kContextKey: contextKey};
+    final rawResult = await _invokeMethod(Constants.mLoadNoCodesScreen, args);
+    final Map<String, dynamic> screenData = jsonDecode(rawResult as String);
+    return QNoCodeScreen.fromMap(screenData);
   }
 
   @override

--- a/lib/src/nocodes.dart
+++ b/lib/src/nocodes.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dto/nocodes_events.dart';
+import 'dto/nocodes_screen.dart';
 import 'dto/nocodes_theme.dart';
 import 'dto/presentation_config.dart';
 import 'nocodes_config.dart';
@@ -80,9 +81,15 @@ abstract class NoCodes {
   Stream<NoCodesActionFinishedEvent> get actionFinishedStream;
 
   /// Stream of screen failed to load events
-  /// 
+  ///
   /// **Platform Support:** iOS and Android. Returns empty stream on macOS.
   Stream<NoCodesScreenFailedToLoadEvent> get screenFailedToLoadStream;
+
+  /// Stream of custom action events. A custom action configured in the builder is
+  /// delivered here with its value — the SDK does not execute anything itself.
+  ///
+  /// **Platform Support:** iOS and Android. Returns empty stream on macOS.
+  Stream<NoCodesCustomActionEvent> get customActionStream;
 
   /// Set screen presentation configuration
   /// 
@@ -100,6 +107,18 @@ abstract class NoCodes {
   ///
   /// **Platform Support:** iOS and Android. No-op on macOS.
   Future<void> showScreen(String contextKey, {Map<String, String>? customVariables});
+
+  /// Load a No-Code screen (from cache or network) without presenting it, so you can decide
+  /// whether to present it or show your own fallback UI before any SDK screen appears.
+  /// Present the screen with [showScreen] — the loaded content is served from cache.
+  ///
+  /// The returned [QNoCodeScreen] exposes the typed default variables configured
+  /// in the builder and the default selected product id.
+  ///
+  /// **Platform Support:** iOS and Android. Throws on macOS.
+  ///
+  /// [contextKey] the context key of the screen to load.
+  Future<QNoCodeScreen> loadScreen(String contextKey);
 
   /// Close No-Codes screen
   /// 

--- a/lib/src/nocodes.dart
+++ b/lib/src/nocodes.dart
@@ -88,6 +88,10 @@ abstract class NoCodes {
   /// Stream of custom action events. A custom action configured in the builder is
   /// delivered here with its value — the SDK does not execute anything itself.
   ///
+  /// Like the other No-Codes event streams, this is backed by a single native event
+  /// channel: only one active subscription is supported at a time — a new listener
+  /// replaces the previous one.
+  ///
   /// **Platform Support:** iOS and Android. Returns empty stream on macOS.
   Stream<NoCodesCustomActionEvent> get customActionStream;
 

--- a/macos/qonversion_flutter.podspec
+++ b/macos/qonversion_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
   s.platform = :osx, '10.12'
-  s.dependency "QonversionSandwich", "7.9.0"
+  s.dependency "QonversionSandwich", "7.10.1"
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'


### PR DESCRIPTION
Brings the No-Codes API from sandwich **7.10.1** (native iOS 6.13.0 / Android nocodes 1.10.0) into the Flutter layer.

[DEV-1189](https://linear.app/qonversion/issue/DEV-1189/flutter-no-codes-loadscreen-defaultvariables-and-custom-action-event)

## Changes
- Sandwich bump → **7.10.1** (ios/macos podspecs + gradle; same trio the `upgrade_sandwich` lane edits).
- `NoCodes.loadScreen(contextKey): Future<QNoCodeScreen>` — load-before-present; `QNoCodeScreen` exposes `id`, `contextKey`, `defaultSelectedProductId` and typed `defaultVariables` (`QScreenVariable` with `kind/key/type/value/stringValue`) + `defaultVariable(key, kind:)` lookup mirroring the native SDKs. Presenting stays on `showScreen` (served from cache). Native side returns the sandwich screen map as JSON (same convention as the main SDK's json completions).
- New `customActionStream` (`NoCodesCustomActionEvent` with `value` getter) fed by the new `qonversion_flutter_nocodes_custom_action` event channel; registered on both platforms and wired into the sandwich `CustomAction` event (the Android `when` was exhaustive and would have silently required this case anyway).

## Verification
- `dart analyze lib` — 0 errors (enhanced-enums avoided: package min SDK is 2.15)
- `flutter pub publish --dry-run` on a clean tree — exit 0 (the CI gate)
- Android `:qonversion_flutter:compileDebugKotlin` against sandwich 7.10.1 ✅
- iOS example build — running, will report in a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEJXqfVNxqoUcKXhSPhWn