### PR TITLE
chore: deprecate public Offerings API

### DIFF
--- a/lib/src/internal/qonversion_internal.dart
+++ b/lib/src/internal/qonversion_internal.dart
@@ -217,6 +217,7 @@ class QonversionInternal implements Qonversion {
     return result;
   }
 
+  @Deprecated('Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs')
   @override
   Future<QOfferings> offerings() async {
     final offeringsString = await _invokeMethod(Constants.mOfferings) as String;

--- a/lib/src/qonversion.dart
+++ b/lib/src/qonversion.dart
@@ -123,7 +123,7 @@ abstract class Qonversion {
   /// For example, you can offer one set of products on a paywall immediately after onboarding and another set of products with discounts later on if a user has not converted.
   /// Offerings allow changing the products offered remotely without releasing app updates.
   ///
-  /// See [Offerings](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details.
+  /// See [Migrate Offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details.
   @Deprecated('Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs')
   Future<QOfferings> offerings();
 

--- a/lib/src/qonversion.dart
+++ b/lib/src/qonversion.dart
@@ -123,7 +123,8 @@ abstract class Qonversion {
   /// For example, you can offer one set of products on a paywall immediately after onboarding and another set of products with discounts later on if a user has not converted.
   /// Offerings allow changing the products offered remotely without releasing app updates.
   ///
-  /// See [Offerings](https://qonversion.io/docs/offerings) for more details.
+  /// See [Offerings](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details.
+  @Deprecated('Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs')
   Future<QOfferings> offerings();
 
   /// You can check if a user is eligible for an introductory offer, including a free trial.


### PR DESCRIPTION
## Summary

Marks the public **Offerings API** as deprecated. Offerings are a legacy Qonversion feature that is being sunset in favor of **Remote Configs**, which is the recommended way to manage paywall products remotely.

## Changes

- Add `@Deprecated(...)` to `Qonversion.offerings()` (the public interface) and to `QonversionInternal.offerings()` (the implementation). Dart does not inherit the annotation, so both declarations are annotated.
- Repoint the `offerings()` dartdoc `@see` link from `qonversion.io/docs/offerings` to the Remote Configs migration guide.

## Not changed

- **Behavior is unchanged.** The method continues to work exactly as before; this only surfaces analyzer deprecation warnings and points integrators to the migration guide.
- DTOs (`QOfferings`, `QOffering`) are intentionally left untouched to avoid a cascade of internal deprecation warnings.
- Version, `CHANGELOG` and `pubspec` are untouched.

## Migration guide

https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs

## Related

- documentation_mintlify#100
- dash-mono#571

Please **do not merge** yet — this is part of a coordinated Offerings sunset across docs, dashboard and SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
