### PR TITLE
feat: expose invalidateRemoteConfigsCache, bump sandwich to 7.12.0 (DEV-1236)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "io.qonversion:sandwich:7.11.0"
+    implementation "io.qonversion:sandwich:7.12.0"
     implementation 'com.google.code.gson:gson:2.9.0'
 }

--- a/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionPlugin.kt
+++ b/android/src/main/kotlin/com/qonversion/flutter/sdk/qonversion_flutter_sdk/QonversionPlugin.kt
@@ -118,6 +118,10 @@ class QonversionPlugin : MethodCallHandler, FlutterPlugin, ActivityAware {
             "isFallbackFileAccessible" -> {
                 return isFallbackFileAccessible(result)
             }
+            "invalidateRemoteConfigsCache" -> {
+                qonversionSandwich.invalidateRemoteConfigsCache()
+                return result.success(null)
+            }
             "remoteConfigList" -> {
                 return remoteConfigList(result)
             }

--- a/ios/Classes/SwiftQonversionPlugin.swift
+++ b/ios/Classes/SwiftQonversionPlugin.swift
@@ -96,6 +96,10 @@ public class SwiftQonversionPlugin: NSObject, FlutterPlugin {
     case "isFallbackFileAccessible":
       return isFallbackFileAccessible(result)
 
+    case "invalidateRemoteConfigsCache":
+      qonversionSandwich?.invalidateRemoteConfigsCache()
+      return result(nil)
+
     case "remoteConfigList":
       return remoteConfigList(result)
         

--- a/ios/qonversion_flutter.podspec
+++ b/ios/qonversion_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '13.0'
-  s.dependency "QonversionSandwich", "7.11.0"
+  s.dependency "QonversionSandwich", "7.12.0"
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -71,6 +71,7 @@ class Constants {
   static const mRemoteConfig = 'remoteConfig';
   static const mRemoteConfigList = 'remoteConfigList';
   static const mRemoteConfigListForContextKeys = 'remoteConfigListForContextKeys';
+  static const mInvalidateRemoteConfigsCache = 'invalidateRemoteConfigsCache';
   static const mAttachUserToExperiment = 'attachUserToExperiment';
   static const mDetachUserFromExperiment = 'detachUserFromExperiment';
   static const mAttachUserToRemoteConfiguration = 'attachUserToRemoteConfiguration';

--- a/lib/src/internal/qonversion_internal.dart
+++ b/lib/src/internal/qonversion_internal.dart
@@ -349,6 +349,11 @@ class QonversionInternal implements Qonversion {
   }
 
   @override
+  Future<void> invalidateRemoteConfigsCache() async {
+    return _invokeMethod(Constants.mInvalidateRemoteConfigsCache);
+  }
+
+  @override
   Future<void> attachUserToExperiment(String experimentId, String groupId) async {
     final args = {
       Constants.kExperimentId: experimentId,

--- a/lib/src/qonversion.dart
+++ b/lib/src/qonversion.dart
@@ -241,7 +241,14 @@ abstract class Qonversion {
   /// reflected immediately, for example after setting a batch of user
   /// properties your remote config targeting depends on. You do NOT need to
   /// call it after [identify] - the SDK invalidates the cache on identity
-  /// changes automatically. Call it after [Qonversion.initialize].
+  /// changes automatically.
+  ///
+  /// If the re-issued load fails, the previously received evaluation is
+  /// delivered instead of an error - the call never degrades below the
+  /// pre-invalidation result.
+  ///
+  /// Call it after [Qonversion.initialize]: calling before initialization
+  /// throws on Android and does nothing on iOS.
   Future<void> invalidateRemoteConfigsCache();
 
   /// This function should be used for the test purposes only. Do not forget to delete the usage of this function before the release.

--- a/lib/src/qonversion.dart
+++ b/lib/src/qonversion.dart
@@ -228,6 +228,22 @@ abstract class Qonversion {
       bool includeEmptyContextKey
   );
 
+  /// Invalidates the cache of remote configs so the next [remoteConfig] or
+  /// [remoteConfigList] call fetches a fresh targeting evaluation from the
+  /// server instead of returning the cached copy.
+  ///
+  /// This method performs no network request itself - it only marks the cached
+  /// values as stale. An in-flight remoteConfig load is re-issued once so its
+  /// waiting calls receive a fresh evaluation; an in-flight remoteConfigList
+  /// completes with the evaluation it started with.
+  ///
+  /// Call it when the targeting inputs changed and you need the change
+  /// reflected immediately, for example after setting a batch of user
+  /// properties your remote config targeting depends on. You do NOT need to
+  /// call it after [identify] - the SDK invalidates the cache on identity
+  /// changes automatically. Call it after [Qonversion.initialize].
+  Future<void> invalidateRemoteConfigsCache();
+
   /// This function should be used for the test purposes only. Do not forget to delete the usage of this function before the release.
   /// Use this function to attach the user to the experiment.
   Future<void> attachUserToExperiment(String experimentId, String groupId);

--- a/macos/Classes/SwiftQonversionPlugin.swift
+++ b/macos/Classes/SwiftQonversionPlugin.swift
@@ -77,6 +77,10 @@ public class SwiftQonversionPlugin: NSObject, FlutterPlugin {
     case "isFallbackFileAccessible":
       return isFallbackFileAccessible(result)
 
+    case "invalidateRemoteConfigsCache":
+      qonversionSandwich?.invalidateRemoteConfigsCache()
+      return result(nil)
+
     case "remoteConfigList":
       return remoteConfigList(result)
 

--- a/macos/qonversion_flutter.podspec
+++ b/macos/qonversion_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
   s.platform = :osx, '10.12'
-  s.dependency "QonversionSandwich", "7.11.0"
+  s.dependency "QonversionSandwich", "7.12.0"
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'


### PR DESCRIPTION
B4 exposure from the Remote Config targeting review ([dash-mono PR #674](https://github.com/qonversion/dash-mono/pull/674)). Linear: [DEV-1236](https://linear.app/qonversion/issue/DEV-1236). Exposes the new cache invalidation API released in [android-sdk 9.7.0](https://github.com/qonversion/android-sdk/releases/tag/sdk%2F9.7.0) / [qonversion-ios-sdk 6.14.0](https://github.com/qonversion/qonversion-ios-sdk/releases/tag/6.14.0), bridged by [sandwich 7.12.0](https://github.com/qonversion/sandwich-sdk/releases/tag/7.12.0).

## What changed

1. **Sandwich pinned to 7.12.0** (Android + iOS). Note: the sandwich pod pins `Qonversion` exactly, so apps that also declare the native `Qonversion` pod directly must move to 6.14.0.
2. **New public API `invalidateRemoteConfigsCache`** — a void no-callback pass-through to the native method. It performs no network request; it marks the remote configs cache stale so the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. An in-flight `remoteConfig` load is re-issued once so its waiting calls receive a fresh evaluation (degrading to the superseded one if the retry fails); an in-flight `remoteConfigList` completes with the evaluation it started with. You do NOT need to call it after `identify` — the SDK invalidates on identity changes automatically. Call it after initialization (calling before initialization crashes on Android and no-ops on iOS, same as the other void bridges). Review round: the macOS platform copy (method channel case + podspec pin) is carried too — macOS has its own plugin file, not a symlink.

## Release notes for this wrapper (minor bump)
- Source-breaking note for the release: the abstract `Qonversion` class gained a new required member — custom implementations and hand-written mocks must add `invalidateRemoteConfigsCache`.


- New: `invalidateRemoteConfigsCache` — invalidate the remote configs cache on demand (e.g. after setting a batch of user properties your targeting depends on).
- Native SDKs updated: Android 9.7.0, iOS 6.14.0 — automatic remote configs cache invalidation on same-uid `identify`, never-worse re-issue of superseded in-flight loads, uncached bundled fallbacks with rate-limit tolerance (remote configs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4V5cx2SMU4VrfPntwfKJ9
