### PR TITLE
Release 11.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.10.0
+* // Update changelog here
+
 ## 11.9.0
 * // Update changelog here
 

--- a/lib/src/internal/qonversion_internal.dart
+++ b/lib/src/internal/qonversion_internal.dart
@@ -11,7 +11,7 @@ import 'package:qonversion_flutter/src/internal/utils/string.dart';
 import 'constants.dart';
 
 class QonversionInternal implements Qonversion {
-  static const String sdkVersion = "11.9.0";
+  static const String sdkVersion = "11.10.0";
 
   final MethodChannel _channel = MethodChannel('qonversion_plugin');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: qonversion_flutter
 description: Flutter plugin to implement in-app subscriptions and purchases. Validate user receipts and manage cross-platform access to paid content on your app. Android & iOS.
-version: 11.9.0
+version: 11.10.0
 homepage: 'https://qonversion.io'
 repository: 'https://github.com/qonversion/flutter-sdk'
 


### PR DESCRIPTION
Release PR

<!-- release-notes:start -->
## New

* New public API `invalidateRemoteConfigsCache` — invalidates the remote configs cache so the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. It performs no network request itself; call it when the targeting inputs changed and you need the change reflected immediately, for example after setting a batch of user properties your targeting depends on. You do not need to call it after `identify` — the SDK invalidates the cache on identity changes automatically (#466).

## Improvements & fixes

* Native SDKs updated via QonversionSandwich 7.12.0: [Android 9.7.0](https://github.com/qonversion/android-sdk/releases/tag/sdk%2F9.7.0) and [iOS 6.14.0](https://github.com/qonversion/qonversion-ios-sdk/releases/tag/6.14.0) — automatic remote configs cache invalidation on same-uid `identify`, never-worse re-issue of superseded in-flight remote config loads, uncached bundled fallbacks with rate-limit tolerance (remote configs only) (#466).
* macOS is carried in lockstep: the new method channel case and the macOS sandwich pin are included (#466).

## Breaking notes

* The abstract `Qonversion` class gained a new required member — custom implementations and hand-written mocks must add `invalidateRemoteConfigsCache`.
* The sandwich pod pins the native `Qonversion` pod exactly: apps that also declare `Qonversion` directly must move to 6.14.0.
<!-- release-notes:end -->
