### PR TITLE
feat: expose frozen Remote Config assignments

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,19 +8,22 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Checkout
       
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         name: Setup Java
         with:
-          java-version: '12.x'
+          distribution: temurin
+          java-version: '17'
           
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         name: Setup Flutter
         with:
           flutter-version: '3.32.4'
           channel: 'stable'
       - run: flutter pub get
+      - name: Verify frozen assignment mapping
+        run: flutter test test/qonversion.dart
       - name: Validation
         run: flutter pub publish --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -22,7 +22,7 @@ jobs:
         run: flutter --version
 
       - name: Cache pub dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.FLUTTER_HOME }}/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
@@ -31,10 +31,13 @@ jobs:
       - name: Download pub dependencies
         run: flutter pub get
 
+      - name: Verify frozen assignment mapping
+        run: flutter test test/qonversion.dart
+
       - name: Setup Pub Credentials
         run: |
-          mkdir -p $HOME/.config/dart
-          cat <<EOF > $HOME/.config/dart/pub-credentials.json
+          mkdir -p "$HOME/.config/dart"
+          cat <<EOF > "$HOME/.config/dart/pub-credentials.json"
           {
             "accessToken": "${{ secrets.PUB_DEV_PUBLISH_ACCESS_TOKEN }}",
             "refreshToken": "${{ secrets.PUB_DEV_PUBLISH_REFRESH_TOKEN }}",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "io.qonversion:sandwich:7.12.0"
+    implementation "io.qonversion:sandwich:7.13.0"
     implementation 'com.google.code.gson:gson:2.9.0'
 }

--- a/ios/qonversion_flutter.podspec
+++ b/ios/qonversion_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '13.0'
-  s.dependency "QonversionSandwich", "7.12.0"
+  s.dependency "QonversionSandwich", "7.13.0"
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/lib/src/dto/remote_configuration_assignment_type.dart
+++ b/lib/src/dto/remote_configuration_assignment_type.dart
@@ -12,4 +12,8 @@ enum QRemoteConfigurationAssignmentType {
   /// Manual
   @JsonValue('manual')
   manual,
+
+  /// Pinned automatically by Remote Config Freeze assignments.
+  @JsonValue('frozen')
+  frozen,
 }

--- a/lib/src/dto/remote_configuration_source.g.dart
+++ b/lib/src/dto/remote_configuration_source.g.dart
@@ -32,4 +32,5 @@ const _$QRemoteConfigurationAssignmentTypeEnumMap = {
   QRemoteConfigurationAssignmentType.unknown: 'unknown',
   QRemoteConfigurationAssignmentType.auto: 'auto',
   QRemoteConfigurationAssignmentType.manual: 'manual',
+  QRemoteConfigurationAssignmentType.frozen: 'frozen',
 };

--- a/macos/qonversion_flutter.podspec
+++ b/macos/qonversion_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
   s.platform = :osx, '10.12'
-  s.dependency "QonversionSandwich", "7.12.0"
+  s.dependency "QonversionSandwich", "7.13.0"
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'

--- a/test/qonversion.dart
+++ b/test/qonversion.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:qonversion_flutter/src/dto/remote_configuration_assignment_type.dart';
+import 'package:qonversion_flutter/src/dto/remote_configuration_source.dart';
 
 void main() {
   const MethodChannel channel = MethodChannel('qonversion_flutter_sdk');
@@ -19,4 +21,15 @@ void main() {
   });
 
   test('test', () async {});
+
+  test('frozen remote configuration assignment keeps its provenance', () {
+    final source = QRemoteConfigurationSource.fromJson({
+      'id': 'rc',
+      'name': 'Remote config',
+      'type': 'remote_configuration',
+      'assignmentType': 'frozen',
+      'contextKey': 'main',
+    });
+    expect(source.assignmentType, QRemoteConfigurationAssignmentType.frozen);
+  });
 }


### PR DESCRIPTION
Adds `frozen` assignment provenance to Flutter and pins Sandwich 7.13.0. Draft/stacked: merge only after qonversion/sandwich-sdk#357 is published. The existing Frozen/Unknown mapping and dependency contract now runs in pull-request CI and before package publication. Static contract and actionlint pass locally; the real Flutter toolchain is exercised by CI.
